### PR TITLE
Wip ui redesign headerbar

### DIFF
--- a/src/paperwork/frontend/mainwindow/__init__.py
+++ b/src/paperwork/frontend/mainwindow/__init__.py
@@ -3619,7 +3619,7 @@ class MainWindow(object):
         self.refresh_label_list()
 
         self.headerbars['right'].set_title(doc.name)
-        self.page_nb['total'].set_label(_("/ %d") % (doc.nb_pages))
+        self.page_nb['total'].set_text(_("/ %d") % (doc.nb_pages))
 
         self.__set_doc_buttons_visible(previous_doc, False)
         self.doc_properties_panel.set_doc(doc)

--- a/src/paperwork/frontend/mainwindow/mainwindow.glade
+++ b/src/paperwork/frontend/mainwindow/mainwindow.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.18.3 -->
 <interface>
-  <requires lib="gtk+" version="3.10"/>
+  <requires lib="gtk+" version="3.14"/>
 
   <object class="GtkAdjustment" id="adjustmentZoom">
     <property name="lower">1</property>

--- a/src/paperwork/frontend/mainwindow/mainwindow.glade
+++ b/src/paperwork/frontend/mainwindow/mainwindow.glade
@@ -318,7 +318,6 @@
           <object class="GtkHeaderBar" id="headerbar_right">
             <property name="visible">True</property>
             <property name="title"></property>
-            <property name="subtitle"><!-- TODO(Jflesch): that's one ugly workaround to keep the GtkEntry at the correct size ... -->                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      </property>
             <property name="show_close_button">True</property>
 
             <!-- start -->
@@ -331,8 +330,9 @@
                   <object class="GtkEntry" id="entryPageNb">
                     <property name="visible">True</property>
                     <property name="text"> </property>
-                    <property name="width_chars">4</property>
-                    <property name="width_request">4</property>
+                    <property name="max_width_chars">3</property>
+                    <property name="width_chars">2</property>
+                    <property name="xalign">1</property>
                     <property name="hexpand">False</property>
                     <style>
                       <class name="page-nb-left"/>

--- a/src/paperwork/frontend/mainwindow/mainwindow.glade
+++ b/src/paperwork/frontend/mainwindow/mainwindow.glade
@@ -1045,6 +1045,9 @@
                     <property name="icon_size">1</property>
                   </object>
                 </child>
+                <style>
+                  <class name="page-nb-left"/>
+                </style>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -1062,6 +1065,9 @@
                     <property name="icon_size">1</property>
                   </object>
                 </child>
+                <style>
+                  <class name="page-nb-right"/>
+                </style>
               </object>
               <packing>
                 <property name="expand">True</property>

--- a/src/paperwork/frontend/mainwindow/mainwindow.glade
+++ b/src/paperwork/frontend/mainwindow/mainwindow.glade
@@ -343,10 +343,12 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="labelTotalPages">
+                  <object class="GtkEntry" id="labelTotalPages">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label" translatable="no"></property>
+                    <property name="max_width_chars">4</property>
+                    <property name="width_chars">3</property>
+                    <property name="xalign">0</property>
                     <property name="sensitive">False</property>
                     <style>
                       <class name="page-nb-center"/>


### PR DESCRIPTION
Please review those patches for some cosmetic glitches listed on #356. Fixing GtkEntry width requires gtk+ 3.12. As gtk+ 3.14 will be shipped with most distros by the time our makeover will be released, let's bump to this version instead.