### PR TITLE
Wip ui redesign headerbar

### DIFF
--- a/src/paperwork/frontend/settingswindow/__init__.py
+++ b/src/paperwork/frontend/settingswindow/__init__.py
@@ -563,18 +563,6 @@ class ActionApplySettings(SimpleAction):
             self.__settings_win.emit("need-reindex")
 
 
-class ActionCancelSettings(SimpleAction):
-
-    def __init__(self, settings_win, config):
-        SimpleAction.__init__(self, "Cancel settings")
-        self.__settings_win = settings_win
-        self.__config = config
-
-    def do(self):
-        self.__settings_win.display_config(self.__config)
-        self.__settings_win.hide()
-
-
 class ActionScanCalibration(SimpleAction):
 
     def __init__(self, settings_win):
@@ -648,13 +636,9 @@ class SettingsWindow(GObject.GObject):
         }
 
         actions = {
-            "apply": (
-                [widget_tree.get_object("buttonSettingsOk")],
-                ActionApplySettings(self, config)
-            ),
-            "cancel": (
-                [widget_tree.get_object("buttonSettingsCancel")],
-                ActionCancelSettings(self, config)
+            "delete-event": (
+                [self.window],
+                ActionApplySettings(self, config),
             ),
             "toggle_ocr": (
                 [self.ocr_settings['enabled']['gui']],

--- a/src/paperwork/frontend/settingswindow/settingswindow.glade
+++ b/src/paperwork/frontend/settingswindow/settingswindow.glade
@@ -99,6 +99,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="label2">
+                                <property name="xalign">1</property>
                                 <property name="width_request">125</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -204,6 +205,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="label7">
+                                <property name="xalign">1</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="label" translatable="yes">Resolution</property>
@@ -215,6 +217,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="label12">
+                                <property name="xalign">1</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="label" translatable="yes">Source</property>
@@ -226,6 +229,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="label6">
+                                <property name="xalign">1</property>
                                 <property name="width_request">125</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -238,6 +242,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="label13">
+                                <property name="xalign">1</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                               </object>
@@ -286,6 +291,7 @@
                             <property name="column_spacing">10</property>
                             <child>
                               <object class="GtkLabel" id="label10">
+                                <property name="xalign">1</property>
                                 <property name="width_request">125</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -298,6 +304,7 @@
                             </child>
                             <child>
                               <object class="GtkLabel" id="label3">
+                                <property name="xalign">1</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                               </object>
@@ -363,6 +370,7 @@
                 </child>
                 <child>
                   <object class="GtkLabel" id="label11">
+                    <property name="xalign">1</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                   </object>
@@ -405,6 +413,7 @@
                                 <property name="can_focus">False</property>
                                 <child>
                                   <object class="GtkLabel" id="label8">
+                                    <property name="xalign">1</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                   </object>

--- a/src/paperwork/frontend/settingswindow/settingswindow.glade
+++ b/src/paperwork/frontend/settingswindow/settingswindow.glade
@@ -34,7 +34,7 @@
     <property name="default_height">600</property>
     <property name="destroy_with_parent">True</property>
     <property name="icon_name">gtk-preferences</property>
-    <property name="use-header-bar">0</property>
+    <property name="use-header-bar">1</property>
 
     <child type="action">
       <object class="GtkLinkButton" id="buttonSettingsHelp">
@@ -47,29 +47,8 @@
         <property name="uri">https://github.com/jflesch/paperwork/wiki</property>
       </object>
     </child>
-    <child type="action">
-      <object class="GtkButton" id="buttonSettingsCancel">
-        <property name="label" translatable="yes">Cancel</property>
-        <property name="use_action_appearance">False</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
-      </object>
-    </child>
-    <child type="action">
-      <object class="GtkButton" id="buttonSettingsOk">
-        <property name="label" translatable="yes">Ok</property>
-        <property name="use_action_appearance">False</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
-      </object>
-    </child>
-
     <action-widgets>
       <action-widget response="help">buttonSettingsHelp</action-widget>
-      <action-widget response="cancel">buttonSettingsCancel</action-widget>
-      <action-widget response="ok" default="true">buttonSettingsOk</action-widget>
     </action-widgets>
 
     <child internal-child="vbox">

--- a/src/paperwork/frontend/settingswindow/settingswindow.glade
+++ b/src/paperwork/frontend/settingswindow/settingswindow.glade
@@ -267,34 +267,6 @@
                                 <property name="top_attach">0</property>
                               </packing>
                             </child>
-                            <child>
-                              <object class="GtkLinkButton" id="linkbutton4">
-                                <property name="label" translatable="yes">Help</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="relief">none</property>
-                                <property name="uri">https://github.com/jflesch/paperwork/wiki/Scanner-source</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">2</property>
-                                <property name="top_attach">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLinkButton" id="linkbutton5">
-                                <property name="label" translatable="yes">Help</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="relief">none</property>
-                                <property name="uri">https://github.com/jflesch/paperwork/wiki/Scanner-resolution</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">2</property>
-                                <property name="top_attach">2</property>
-                              </packing>
-                            </child>
                           </object>
                         </child>
                       </object>
@@ -391,34 +363,6 @@
                                 <property name="top_attach">0</property>
                               </packing>
                             </child>
-                            <child>
-                              <object class="GtkLinkButton" id="linkbutton1">
-                                <property name="label" translatable="yes">Help</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="relief">none</property>
-                                <property name="uri">https://github.com/jflesch/paperwork/wiki/OCR-enabled</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">2</property>
-                                <property name="top_attach">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLinkButton" id="linkbutton2">
-                                <property name="label" translatable="yes">Help</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="relief">none</property>
-                                <property name="uri">https://github.com/jflesch/paperwork/wiki/OCR-language</property>
-                              </object>
-                              <packing>
-                                <property name="left_attach">2</property>
-                                <property name="top_attach">1</property>
-                              </packing>
-                            </child>
                           </object>
                         </child>
                       </object>
@@ -489,21 +433,6 @@
                                     <property name="expand">True</property>
                                     <property name="fill">True</property>
                                     <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLinkButton" id="linkbutton7">
-                                    <property name="label" translatable="yes">Help</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                    <property name="relief">none</property>
-                                    <property name="uri">https://github.com/jflesch/paperwork/wiki/Scanner-calibration</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
                                   </packing>
                                 </child>
                                 <child>

--- a/src/paperwork/frontend/settingswindow/settingswindow.glade
+++ b/src/paperwork/frontend/settingswindow/settingswindow.glade
@@ -25,7 +25,7 @@
       <column type="gchararray"/>
     </columns>
   </object>
-  <object class="GtkWindow" id="windowSettings">
+  <object class="GtkDialog" id="windowSettings">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Settings</property>
     <property name="modal">True</property>
@@ -34,7 +34,33 @@
     <property name="default_height">600</property>
     <property name="destroy_with_parent">True</property>
     <property name="icon_name">gtk-preferences</property>
-    <child>
+    <property name="use-header-bar">0</property>
+
+    <child type="action">
+      <object class="GtkButton" id="buttonSettingsCancel">
+        <property name="label" translatable="yes">Cancel</property>
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">True</property>
+      </object>
+    </child>
+    <child type="action">
+      <object class="GtkButton" id="buttonSettingsOk">
+        <property name="label" translatable="yes">Ok</property>
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="receives_default">True</property>
+      </object>
+    </child>
+
+    <action-widgets>
+      <action-widget response="cancel">buttonSettingsCancel</action-widget>
+      <action-widget response="ok" default="true">buttonSettingsOk</action-widget>
+    </action-widgets>
+
+    <child internal-child="vbox">
       <object class="GtkBox" id="vbox2">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
@@ -566,48 +592,6 @@
             <property name="expand">True</property>
             <property name="fill">True</property>
             <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkButtonBox" id="hbuttonbox1">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="spacing">10</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="buttonSettingsCancel">
-                <property name="label" translatable="yes">Cancel</property>
-                <property name="use_action_appearance">False</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="buttonSettingsOk">
-                <property name="label" translatable="yes">Ok</property>
-                <property name="use_action_appearance">False</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="padding">6</property>
-            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/src/paperwork/frontend/settingswindow/settingswindow.glade
+++ b/src/paperwork/frontend/settingswindow/settingswindow.glade
@@ -37,6 +37,17 @@
     <property name="use-header-bar">0</property>
 
     <child type="action">
+      <object class="GtkLinkButton" id="buttonSettingsHelp">
+        <property name="label" translatable="yes">Help</property>
+        <property name="use_action_appearance">False</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="use_action_appearance">False</property>
+        <property name="use_underline">True</property>
+        <property name="uri">https://github.com/jflesch/paperwork/wiki</property>
+      </object>
+    </child>
+    <child type="action">
       <object class="GtkButton" id="buttonSettingsCancel">
         <property name="label" translatable="yes">Cancel</property>
         <property name="use_action_appearance">False</property>
@@ -56,6 +67,7 @@
     </child>
 
     <action-widgets>
+      <action-widget response="help">buttonSettingsHelp</action-widget>
       <action-widget response="cancel">buttonSettingsCancel</action-widget>
       <action-widget response="ok" default="true">buttonSettingsOk</action-widget>
     </action-widgets>

--- a/src/paperwork/frontend/util/actions.py
+++ b/src/paperwork/frontend/util/actions.py
@@ -47,6 +47,7 @@ class SimpleAction(object):
             (Gio.Action, "activate", self.on_action_activated_cb, -1),
             (Gtk.ListBox, "row-selected", self.on_row_selected_cb, -1),
             (Gtk.Calendar, "day-selected", self.on_day_selected_cb, -1),
+            (Gtk.Dialog, "delete-event", self.on_dialog_closed_cb, -1),
         ]
         self.enabled = True
 
@@ -95,6 +96,9 @@ class SimpleAction(object):
         return self.__do()
 
     def on_day_selected_cb(self, calendar):
+        return self.__do()
+
+    def on_dialog_closed_cb(self, dialog, config):
         return self.__do()
 
     def connect(self, buttons):


### PR DESCRIPTION
Hi j,

This request is about short changes for the preferences dialog. As hinted in a [previous comment](https://github.com/jflesch/paperwork/issues/356#issuecomment-77370927), it does the following:

- use a proper GtkDialog with a headerbar
- replace Cancel/Apply/Close (which we don't know if it cancels or applies changes) buttons with a single close button (which does apply changes)
- replace 5 helps button with a single one
- fix labels alignement (to get a bit closer to the gnome HIG)

Regards