### PR TITLE
Fixed the .desktop categories not adhering to the FreeDesktop standard

### DIFF
--- a/data/paperwork.desktop
+++ b/data/paperwork.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Categories=Office;
+Categories=Graphics;Scanning;
 Terminal=false
 Comment=Make dead trees grepable
 Exec=paperwork


### PR DESCRIPTION
See https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories#Graphics Some distributions are rather strict about it. openSUSE will cancel the build on OBS, but hey we are Germans.