### PR TITLE
Add fedora dependency for gnome symbolic icons

### DIFF
--- a/src/paperwork/deps.py
+++ b/src/paperwork/deps.py
@@ -77,6 +77,7 @@ DATA_FILES = [
         {
             'debian': 'gnome-icon-theme-symbolic',
             'ubuntu': 'gnome-icon-theme-symbolic',
+            'fedora': 'gnome-icon-theme-symbolic',
         }
     ),
 ]


### PR DESCRIPTION
Added missing dependency for the gnome-icon-theme-symbolic package in Fedora 24.

**Before:**

Command `paperwork-shell chkdeps paperwork` shows an warning that the
`go-previous-symbolic.svg` is missing. But it's not asking to install the needed package
like under Debian or Ubuntu.

**After:**

Above mentioned command fires up yum/dnf to install the missing
`gnome-icon-theme-symbolic` RPM package.